### PR TITLE
Initial migration -> Toblerity org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,32 @@
+sudo: false
+
 language: python
 
+cache:
+  directories:
+    - ~/.cache/pip
+
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+
+addons:
+  apt:
+    packages:
+    - libgdal1h
+    - gdal-bin
+    - libgdal-dev
+    - libatlas-dev
+    - libatlas-base-dev
+    - gfortran
 
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntugis/ppa
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libgdal1h gdal-bin libgdal-dev
+  - pip install pip setuptools --upgrade
 
 install:
-  - "pip install -e .[dev]"
+  - pip install -e .[dev]
 
 script: 
   - py.test tests --cov fio_buffer --cov-report term-missing

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 New BSD License
 
-Copyright (c) 2014, Kevin D. Wurster
+Copyright (c) 2015-2016, Kevin D. Wurster
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -13,8 +13,9 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* The names of its contributors may not be used to endorse or promote products
-  derived from this software without specific prior written permission.
+* The names of fio-buffer not its contributors may not be used to endorse or
+  promote products derived from this software without specific prior written
+  permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 fio-buffer
 ==========
 
-.. image:: https://travis-ci.org/geowurster/fio-buffer.svg?branch=master
-    :target: https://travis-ci.org/geowurster/fio-buffer?branch=master
+.. image:: https://travis-ci.org/toblerity/fio-buffer.svg?branch=master
+    :target: https://travis-ci.org/toblerity/fio-buffer?branch=master
 
-.. image:: https://coveralls.io/repos/geowurster/fio-buffer/badge.svg?branch=master
-    :target: https://coveralls.io/r/geowurster/fio-buffer?branch=master
+.. image:: https://coveralls.io/repos/toblerity/fio-buffer/badge.svg?branch=master
+    :target: https://coveralls.io/r/toblerity/fio-buffer?branch=master
 
 A `Fiona <http://toblerity.org/fiona/manual.html>`_  CLI plugin for buffering geometries in parallel.  Powered by `Shapely <http://toblerity.org/shapely/manual.html#object.buffer>`_.
 
@@ -104,7 +104,7 @@ From source:
 
 .. code-block:: console
 
-    $ git clone https://github.com/geowurster/fio-buffer
+    $ git clone https://github.com/toblerity/fio-buffer
     $ cd fio-buffer
     $ python setup.py install
 
@@ -114,7 +114,7 @@ Developing
 
 .. code-block:: console
 
-    $ git clone https://github.com/geowurster/fio-buffer
+    $ git clone https://github.com/toblerity/fio-buffer
     $ cd fio-buffer
     $ virtualenv venv
     $ source venv/bin/activate

--- a/fio_buffer/__init__.py
+++ b/fio_buffer/__init__.py
@@ -6,11 +6,11 @@ A Fiona CLI plugin for buffering geometries.
 __version__ = '0.1.1'
 __author__ = 'Kevin Wurster'
 __email__ = 'wursterk@gmail.com'
-__source__ = 'https://github.com/geowurster/fio-buffer'
+__source__ = 'https://github.com/toblerity/fio-buffer'
 __license__ = '''
 New BSD License
 
-Copyright (c) 2015, Kevin D. Wurster
+Copyright (c) 2015-2016, Kevin D. Wurster
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* The names of fio-buffer or its contributors may not be used to endorse or
+* The names of fio-buffer nor its contributors may not be used to endorse or
   promote products derived from this software without specific prior written
   permission.
 


### PR DESCRIPTION
Closes #6 

`fio-buffer` is now owned by Toblerity.
